### PR TITLE
ci：新增 Strix 快速安全掃描工作流程

### DIFF
--- a/.github/workflows/strix.yml.yml
+++ b/.github/workflows/strix.yml.yml
@@ -1,0 +1,35 @@
+name: strix-penetration-test
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  security-scan:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install controlled Strix release
+        env:
+          STRIX_RELEASE_URL: https://github.com/NICS-Software-Security-Research/strix/releases/download/v1.3.1-nics.2/strix-1.3.1-linux-x86_64.tar.gz
+          STRIX_RELEASE_SHA256: 8e32a9383d7470c0f0e11ed8fed73dcaba0b4d0fa40da0bab202a34b1f286b67
+        run: |
+          strix_dir="$RUNNER_TEMP/nics-strix"
+          archive="$strix_dir/strix.tar.gz"
+          mkdir -p "$strix_dir/bin"
+          curl --fail --location --retry 3 --silent --show-error "$STRIX_RELEASE_URL" --output "$archive"
+          echo "$STRIX_RELEASE_SHA256  $archive" | sha256sum --check --
+          tar -xzf "$archive" -C "$strix_dir"
+          install -m 0755 "$strix_dir/strix-1.3.1-linux-x86_64" "$strix_dir/bin/strix"
+          "$strix_dir/bin/strix" --version
+          echo "$strix_dir/bin" >> "$GITHUB_PATH"
+      - name: Run Strix
+        env:
+          STRIX_LLM: ${{ secrets.STRIX_LLM }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_API_BASE: ${{ secrets.LLM_API_BASE }}
+          STRIX_OPENAI_API_MODE: responses
+        run: strix -n -t ./ --scan-mode quick


### PR DESCRIPTION
## 說明

新增 GitHub Actions 工作流程，在 Pull Request 建立時自動執行 Strix 快速安全掃描。

## 變更內容

- 新增 Strix 安全掃描工作流程。
- 僅允許同一個 Repository 的 Pull Request 執行。
- 使用唯讀權限，降低工作流程權限。
- 下載指定版本的 Strix，並驗證 SHA-256。
- 使用 GitHub Secrets 設定 LLM 服務。
- 以快速掃描模式檢查整個 Repository。

## 變更類型

- [x] 新功能
- [ ] Bug 修正
- [ ] 文件更新
- [ ] 其他

## 測試方式

尚待 GitHub Actions 執行確認。

## 相關 Issue

無。